### PR TITLE
Handle multiple line endings in during SetupCommand

### DIFF
--- a/Tools/ModdingToolkit/Tools/Modding/Modder/Commands/SetupCommand.cs
+++ b/Tools/ModdingToolkit/Tools/Modding/Modder/Commands/SetupCommand.cs
@@ -57,7 +57,10 @@ namespace ModdingToolkit.Tools.Modding.Modder.Commands
                     .CreateSubdirectory("net452");
 
             Console.WriteLine("Copying all required files and folder into target debug folder...");
-            _texts.SetupDebugCopy.Split(Environment.NewLine).Do(s =>
+            _texts.SetupDebugCopy.Split(
+                new string[] { "\r\n", "\r", "\n" },
+                StringSplitOptions.None
+                ).Do(s =>
             {
                 Console.Write($"Copying {s}... ");
 


### PR DESCRIPTION
I was having issues with `Environment.NewLine` because my line terminater is `\n` not `\r\n`
This change will split the string by any of these strings `["\r\n", "\r", "\n"]` so pretty much any line ending.

- [x] runs and works locally